### PR TITLE
chore: Add further diagnostic logging for HTTP client call

### DIFF
--- a/notification-watcher/src/notification_watcher/core.clj
+++ b/notification-watcher/src/notification_watcher/core.clj
@@ -33,12 +33,14 @@
     (let [url (str "https://api.gupshup.io/sm/api/v1/template/list/" app-id)]
       (println (str "[WORKER] Tentando conexão com a API. App ID: " app-id ", URL: " url))
       (try
+        (println "[WORKER] PREPARANDO PARA EXECUTAR client/get...")
         (let [response (client/get url {:headers          {:apikey token}
                                         :as               :json ; Tenta parsear como JSON, mas precisamos verificar o status antes
                                         :throw-exceptions false ; Importante para podermos inspecionar respostas não-200
-                                        :conn-timeout     15000
-                                        :socket-timeout   15000})]
-
+                                        :conn-timeout     60000 ; Aumentado para 60s
+                                        :socket-timeout   60000 ; Aumentado para 60s
+                                        })]
+          (println "[WORKER] client/get EXECUTADO. Processando resposta...")
           (println (str "[WORKER] Resposta recebida da API. Status HTTP: " (:status response)))
 
           (if (= (:status response) 200)


### PR DESCRIPTION
This commit adds more detailed logging around the `client/get` call within the `fetch-templates` function and increases timeouts.

- Timeouts (`conn-timeout` and `socket-timeout`) for the HTTP call have been increased to 60 seconds to rule out slightly longer-than-expected response times causing issues in the Render environment.
- A log message is now printed immediately before the `client/get` call is made.
- A log message is now printed immediately after the `client/get` call returns, before any attempt to process the response.

These changes are intended to help diagnose whether the HTTP call is blocking indefinitely, being terminated externally, or returning an unexpected result that prevents further log messages from appearing.