### PR TITLE
chore: Temporarily switch to test URL for diagnosing HTTP client

### DIFF
--- a/notification-watcher/src/notification_watcher/core.clj
+++ b/notification-watcher/src/notification_watcher/core.clj
@@ -30,18 +30,20 @@
       (println "[MODO DE TESTE ATIVADO] Usando dados mockados.")
       mock-templates-com-mudanca)
 
-    (let [url (str "https://api.gupshup.io/sm/api/v1/template/list/" app-id)]
-      (println (str "[WORKER] Tentando conexão com a API. App ID: " app-id ", URL: " url))
+    (let [;;url (str "https://api.gupshup.io/sm/api/v1/template/list/" app-id) ; URL Original comentada
+          url "https://jsonplaceholder.typicode.com/todos/1" ; URL de Teste
+          ]
+      (println (str "[WORKER] Tentando conexão com API DE TESTE. URL: " url))
       (try
-        (println "[WORKER] PREPARANDO PARA EXECUTAR client/get...")
-        (let [response (client/get url {:headers          {:apikey token}
-                                        :as               :json ; Tenta parsear como JSON, mas precisamos verificar o status antes
-                                        :throw-exceptions false ; Importante para podermos inspecionar respostas não-200
-                                        :conn-timeout     60000 ; Aumentado para 60s
-                                        :socket-timeout   60000 ; Aumentado para 60s
+        (println "[WORKER] PREPARANDO PARA EXECUTAR client/get (TESTE)...")
+        (let [response (client/get url {;;:headers          {:apikey token} ; Removido para URL de teste
+                                        :as               :json
+                                        :throw-exceptions false
+                                        :conn-timeout     60000
+                                        :socket-timeout   60000
                                         })]
-          (println "[WORKER] client/get EXECUTADO. Processando resposta...")
-          (println (str "[WORKER] Resposta recebida da API. Status HTTP: " (:status response)))
+          (println "[WORKER] client/get (TESTE) EXECUTADO. Processando resposta...")
+          (println (str "[WORKER] Resposta recebida da API DE TESTE. Status HTTP: " (:status response)))
 
           (if (= (:status response) 200)
             (do


### PR DESCRIPTION
This commit modifies the `fetch-templates` function to target a public test API (`https://jsonplaceholder.typicode.com/todos/1`) instead of the Gupshup API.

The following changes were made:
- The original Gupshup API URL is commented out.
- The `url` variable is set to `https://jsonplaceholder.typicode.com/todos/1`.
- The `:apikey` header is commented out from the `client/get` call as it's not needed for the test URL.
- Log messages have been updated to reflect that a test API call is being made.

This change is intended to help determine if the `clj-http` client can make any successful external HTTPS calls from the Render environment, or if the issue is specific to connecting to the Gupshup API.