### PR TITLE
fix: Add cheshire dependency for JSON parsing

### DIFF
--- a/notification-watcher/project.clj
+++ b/notification-watcher/project.clj
@@ -9,6 +9,9 @@
                  ;; Cliente HTTP para consumir a API da Gupshup
                  [clj-http "3.12.3"]
 
+                 ;; Parser JSON (necessário para :as :json com clj-http)
+                 [cheshire "5.12.0"]
+
                  ;; Servidor web e roteamento (abordagem moderna)
                  [http-kit "2.7.0"]
                  [metosin/reitit-ring "0.7.0-alpha7"]]


### PR DESCRIPTION
This commit adds `cheshire` as a project dependency.

The `clj-http` library, when used with the `:as :json` option, requires a JSON parsing library to be present on the classpath. The absence of such a library was causing an `AssertionError: Assert failed: json-enabled?` during the HTTP request processing.

Adding `cheshire` resolves this issue and enables `clj-http` to correctly parse JSON responses.