### PR TITLE
fix: Correct category change detection and revert to 10-min interval

### DIFF
--- a/notification-watcher/src/notification_watcher/core.clj
+++ b/notification-watcher/src/notification_watcher/core.clj
@@ -34,14 +34,14 @@
           ]
       (println (str "[WORKER] Tentando conexão com a API Gupshup. App ID: " app-id ", URL: " url))
       (try
-        (println "[WORKER] PREPARANDO PARA EXECUTAR client/get...")
+        ;; (println "[WORKER] PREPARANDO PARA EXECUTAR client/get...") ; Log de depuração removido
         (let [response (client/get url {:headers          {:apikey token} ; Header restaurado
                                         :as               :json
                                         :throw-exceptions false
                                         :conn-timeout     60000
                                         :socket-timeout   60000
                                         })]
-          (println "[WORKER] client/get EXECUTADO. Processando resposta...")
+          ;; (println "[WORKER] client/get EXECUTADO. Processando resposta...") ; Log de depuração removido
           (println (str "[WORKER] Resposta recebida da API Gupshup. Status HTTP: " (:status response)))
 
           (if (= (:status response) 200)
@@ -63,10 +63,10 @@
 
 (defn log-category-change
   [template]
-  (let [id          (get template "id")
-        elementName (get template "elementName")
-        oldCategory (get template "oldCategory")
-        newCategory (get template "category")]
+  (let [id          (get template :id)
+        elementName (get template :elementName)
+        oldCategory (get template :oldCategory)
+        newCategory (get template :category)]
     (println (str "[WORKER] Mudança de categoria detectada para o template:"))
     (println (str "  ID: " id))
     (println (str "  Nome: " elementName))
@@ -77,7 +77,7 @@
   [app-id token]
   (println "[WORKER] Executando verificação de templates...")
   (if-let [all-templates (fetch-templates app-id token)]
-    (let [templates-with-old-category (filter #(contains? % "oldCategory") all-templates)
+    (let [templates-with-old-category (filter #(contains? % :oldCategory) all-templates) ; Alterado para keyword
           count-changed (count templates-with-old-category)]
       (if (pos? count-changed)
         (do
@@ -104,15 +104,15 @@
         (loop []
           (try
             (check-for-changes app-id token)
-            (println "[WORKER] Verificação concluída. Próximo ciclo em 2 minutos.")
+            (println "[WORKER] Verificação concluída. Próximo ciclo em 10 minutos.")
             (catch Throwable t ; Captura qualquer Throwable
               (println "\n!!!! [WORKER] Exceção INESPERADA no loop principal do watcher !!!!")
               (println (str "Tipo da exceção: " (type t)))
               (println (str "Mensagem: " (.getMessage t)))
               (.printStackTrace t)
               (println "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-              (println "[WORKER] Erro no ciclo. Tentando novamente em 2 minutos.")))
-          (Thread/sleep 120000) ; Intervalo de 2 minutos
+              (println "[WORKER] Erro no ciclo. Tentando novamente em 10 minutos.")))
+          (Thread/sleep 600000) ; Intervalo de 10 minutos
           (recur)))
       (println "ERRO CRÍTICO: Variáveis de ambiente não definidas."))))
 


### PR DESCRIPTION
This commit addresses a logic error in template category change detection and reverts the watcher polling interval to 10 minutes. Additionally, some verbose debugging logs have been cleaned up.

- In `check-for-changes`:
    - The filter for detecting templates with changed categories now correctly checks for the keyword `:oldCategory` instead of the string "oldCategory". This aligns with how `clj-http` (with `cheshire`) parses JSON keys.
    - The `log-category-change` function has been updated to access template fields using keywords (e.g., `:id`, `:elementName`).

- In `start-watcher-loop!`:
    - The polling interval is set back to 10 minutes (600,000 ms).
    - Log messages related to the polling interval have been updated accordingly.

- In `fetch-templates`:
    - Verbose debugging logs ("PREPARANDO PARA EXECUTAR client/get..." and "client/get EXECUTADO...") have been commented out to reduce log noise now that the primary connectivity issue is resolved.