### PR TITLE
Feat: Expose changed templates API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,125 @@
 # notification-watcher
+
+O `notification-watcher` é um microsserviço em Clojure responsável por monitorar mudanças de categoria em templates de mensagens na plataforma Gupshup para múltiplos WABA IDs (WhatsApp Business Account IDs).
+
+Ele é projetado para:
+1.  Obter uma lista de WABA IDs a serem monitorados, seja através de uma variável de ambiente (para mocking) ou de um serviço de gerenciamento de clientes (`customer-manager-service`).
+2.  Consultar a API da Gupshup periodicamente para cada WABA ID para buscar o status atual dos templates de mensagens.
+3.  Detectar templates que tiveram suas categorias alteradas (ex: de MARKETING para UTILITY).
+4.  Expor um endpoint HTTP (`/changed-templates`) que outros serviços (como um `sms-notifier`) podem consumir para obter a lista de templates com categorias alteradas.
+
+## Configuração
+
+O serviço é configurado através de variáveis de ambiente:
+
+| Variável                           | Descrição                                                                                                                               | Obrigatório | Exemplo                                                                 |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------- |
+| `PORT`                             | Porta na qual o servidor HTTP irá rodar.                                                                                                | Não         | `8080` (valor padrão)                                                   |
+| `GUPSHUP_TOKEN`                    | Token de API para autenticação com a API da Gupshup.                                                                                      | **Sim**     | `abcdef123456xyz`                                                       |
+| `GUPSHUP_MOCK_MODE`                | Se `"true"`, o serviço usará dados mockados para as chamadas à API da Gupshup, em vez de fazer chamadas reais. Útil para desenvolvimento.   | Não         | `true`                                                                  |
+| `MOCK_CUSTOMER_MANAGER_WABA_IDS`   | Uma lista de WABA IDs separados por vírgula para serem usados quando o `customer-manager-service` real não está disponível ou para testes. | Não         | `111222333,444555666`                                                   |
+| `CUSTOMER_MANAGER_URL`             | A URL base do `customer-manager-service` de onde a lista de WABA IDs ativos será buscada. Ignorado se `MOCK_CUSTOMER_MANAGER_WABA_IDS` estiver definido. | Não         | `http://customer-manager-service:8000`                                  |
+
+**Ordem de precedência para WABA IDs:**
+1.  Se `MOCK_CUSTOMER_MANAGER_WABA_IDS` estiver definido, seus valores serão usados.
+2.  Caso contrário, se `CUSTOMER_MANAGER_URL` estiver definido, o serviço tentará buscar os WABA IDs desta URL.
+3.  Se nenhum dos dois estiver definido, o watcher não terá WABA IDs para processar (um erro será logado).
+
+**Ordem de precedência para dados da Gupshup:**
+1.  Se `GUPSHUP_MOCK_MODE` for `"true"`, dados mockados serão gerados para os WABA IDs obtidos (conforme a lógica acima). A estrutura dos dados mockados simula a resposta da API da Gupshup, incluindo templates com e sem `oldCategory`.
+2.  Caso contrário, chamadas reais à API da Gupshup serão feitas.
+
+## Endpoints da API
+
+### `GET /`
+*   **Descrição:** Endpoint básico para verificar se o serviço está no ar ("keep-alive").
+*   **Resposta (200 OK):**
+    ```text
+    Serviço Notification Watcher está no ar.
+    ```
+
+### `GET /changed-templates`
+*   **Descrição:** Retorna uma lista de templates que foram identificados com mudança de categoria desde a última verificação bem-sucedida. A lista é atualizada periodicamente pelo worker em background.
+*   **Resposta (200 OK):**
+    *   Corpo: Um array JSON contendo objetos de template. Cada objeto representa um template que mudou de categoria.
+    *   Exemplo de corpo da resposta:
+        ```json
+        [
+          {
+            "id": "tpl_changed_111222333_2",
+            "elementName": "Template Alterado 111222333 Bravo",
+            "wabaId": "111222333",
+            "category": "UTILITY",
+            "oldCategory": "MARKETING",
+            "status": "APPROVED",
+            "language": "en_US"
+          },
+          {
+            "id": "tpl_another_changed_444555666_4",
+            "elementName": "Outro Alterado 444555666 Delta",
+            "wabaId": "444555666",
+            "category": "AUTHENTICATION",
+            "oldCategory": "UTILITY",
+            "status": "APPROVED",
+            "language": "pt_BR"
+          }
+        ]
+        ```
+    *   Se nenhum template com mudança for encontrado, retorna um array JSON vazio `[]`.
+
+## Como Executar (Desenvolvimento)
+
+1.  **Clone o repositório.**
+2.  **Instale as dependências do Leiningen:**
+    ```bash
+    lein deps
+    ```
+3.  **Configure as variáveis de ambiente:**
+    Crie um arquivo `.env` (se usar uma ferramenta como `dotenv` com Leiningen, ou exporte-as manualmente):
+    ```bash
+    export GUPSHUP_TOKEN="seu_token_real_ou_mock"
+    export GUPSHUP_MOCK_MODE="true"
+    # Para usar WABA IDs mockados:
+    export MOCK_CUSTOMER_MANAGER_WABA_IDS="waba_id_1,waba_id_2,waba_id_3"
+    # OU, para usar um customer-manager-service real (exemplo):
+    # export CUSTOMER_MANAGER_URL="http://localhost:8001"
+    # (descomente e ajuste conforme necessário, e remova ou comente MOCK_CUSTOMER_MANAGER_WABA_IDS)
+    export PORT="8080"
+    ```
+4.  **Execute a aplicação:**
+    ```bash
+    lein run
+    ```
+    O servidor iniciará na porta especificada (padrão 8080) e o watcher começará a rodar em background.
+
+## Como Construir para Produção
+
+Para criar um uberjar (arquivo JAR auto-contido):
+```bash
+lein uberjar
+```
+O arquivo JAR resultante estará em `target/uberjar/notification-watcher-0.1.0-SNAPSHOT-standalone.jar` (o nome pode variar ligeiramente). Você pode então executar este JAR em um ambiente Java:
+```bash
+java -jar target/uberjar/notification-watcher-0.1.0-SNAPSHOT-standalone.jar
+```
+Lembre-se de configurar as variáveis de ambiente necessárias no ambiente de produção.
+
+## Exemplo de Configuração no Render
+
+Se você estiver fazendo deploy no Render.com, você configuraria as variáveis de ambiente na seção "Environment" do seu serviço:
+
+*   `GUPSHUP_TOKEN`: `seu_token_real_da_gupshup`
+*   `PORT`: `10000` (O Render geralmente define a porta, mas se você precisar especificar, use a que o Render espera)
+
+Para **iniciar com WABA IDs mockados** no Render:
+*   `GUPSHUP_MOCK_MODE`: `true`
+*   `MOCK_CUSTOMER_MANAGER_WABA_IDS`: `seu_waba_id_atual_do_gupshup,outro_waba_id_se_necessario`
+
+    *Substitua `seu_waba_id_atual_do_gupshup` pelo App ID da Gupshup que você usa hoje. Você pode adicionar mais IDs separados por vírgula.*
+
+Para **conectar ao `customer-manager-service` real** no futuro (depois que ele estiver pronto e deployado no Render com sua própria URL de serviço interna, por exemplo `customer-manager.onrender.com`):
+*   `GUPSHUP_MOCK_MODE`: `false` (ou omita, pois o padrão é não mockar a Gupshup)
+*   `CUSTOMER_MANAGER_URL`: `http://customer-manager.onrender.com` (substitua pela URL correta do seu serviço)
+*   Remova ou deixe em branco `MOCK_CUSTOMER_MANAGER_WABA_IDS`.
+
+O serviço `notification-watcher` então chamaria `http://customer-manager.onrender.com/internal/customers/active-waba-ids` para obter a lista de WABA IDs.

--- a/notification-watcher/src/notification_watcher/core.clj
+++ b/notification-watcher/src/notification_watcher/core.clj
@@ -1,167 +1,277 @@
 (ns notification-watcher.core
   (:require [clj-http.client :as client]
             [org.httpkit.server :as server]
-            [clojure.pprint :as pprint])
+            [clojure.pprint :as pprint]
+            [clojure.string :as str]
+            [clojure.data.json :as json]) ; Added for JSON manipulation
   (:gen-class))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;  1. FEATURE FLAG E DADOS DE TESTE
+;;  1. CONFIGURAÇÃO E ESTADO
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def mock-mode?
-  (= (System/getenv "MOCK_MODE") "true"))
+(def gupshup-mock-mode?
+  (= (System/getenv "GUPSHUP_MOCK_MODE") "true"))
 
-(def mock-templates-com-mudanca
-  [{"elementName" "template_normal_1", "wabaId" "111222333", "category" "MARKETING"}
-   {"elementName" "template_que_mudou", "wabaId" "444555666", "category" "UTILITY", "oldCategory" "MARKETING"}
-   {"elementName" "template_normal_2", "wabaId" "777888999", "category" "AUTHENTICATION"}])
+(def customer-manager-mock-waba-ids-str
+  (System/getenv "MOCK_CUSTOMER_MANAGER_WABA_IDS"))
+
+(def customer-manager-url
+  (System/getenv "CUSTOMER_MANAGER_URL"))
+
+(def gupshup-token
+  (System/getenv "GUPSHUP_TOKEN"))
+
+;; Atom para armazenar os templates mockados, chaveados por WABA ID
+(def mock-templates-store (atom {}))
+
+;; Atom para armazenar a lista de templates que tiveram mudança de categoria detectada
+(defonce changed-templates-atom (atom []))
+
+(defn- generate-mock-templates-for-waba [waba-id]
+  [{"id" (str "tpl_normal_" waba-id "_1") "elementName" (str "Template Normal " waba-id " Alpha") "wabaId" waba-id "category" "MARKETING" "status" "APPROVED" "language" "pt_BR"}
+   {"id" (str "tpl_changed_" waba-id "_2") "elementName" (str "Template Alterado " waba-id " Bravo") "wabaId" waba-id "category" "UTILITY" "oldCategory" "MARKETING" "status" "APPROVED" "language" "en_US"}
+   {"id" (str "tpl_failed_" waba-id "_3") "elementName" (str "Template Falhado " waba-id " Charlie") "wabaId" waba-id "category" "AUTHENTICATION" "status" "FAILED" "language" "es_ES"}
+   {"id" (str "tpl_another_changed_" waba-id "_4") "elementName" (str "Outro Alterado " waba-id " Delta") "wabaId" waba-id "category" "AUTHENTICATION" "oldCategory" "UTILITY" "status" "APPROVED" "language" "pt_BR"}])
+
+(defn- initialize-mock-gupshup-store! []
+  (when gupshup-mock-mode?
+    (println "[MOCK_SETUP] GUPSHUP_MOCK_MODE está ativo.")
+    (let [mock-waba-ids (if customer-manager-mock-waba-ids-str
+                          (map str/trim (str/split customer-manager-mock-waba-ids-str #","))
+                          ["mock_waba_id_default1" "mock_waba_id_default2"])] ; Fallback se MOCK_CUSTOMER_MANAGER_WABA_IDS não estiver setado mas GUPSHUP_MOCK_MODE sim
+      (println (str "[MOCK_SETUP] Populando mock store para WABA IDs: " mock-waba-ids))
+      (doseq [waba-id mock-waba-ids]
+        (swap! mock-templates-store assoc waba-id (generate-mock-templates-for-waba waba-id)))
+      (println (str "[MOCK_SETUP] Mock store populado: " @mock-templates-store)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;  2. FUNÇÕES DE LÓGICA DO WATCHER (COM LOG DA RESPOSTA BRUTA)
+;;  2. FUNÇÕES DE LÓGICA DO WATCHER
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn fetch-templates
-  "Busca templates. Usa dados de teste ou chama a API real e LOGA A RESPOSTA BRUTA."
-  [app-id token]
-  (if mock-mode?
+(defn fetch-waba-ids
+  "Busca WABA IDs do customer-manager-service ou usa mock."
+  []
+  (if customer-manager-mock-waba-ids-str
     (do
-      (println "[MODO DE TESTE ATIVADO] Usando dados mockados.")
-      mock-templates-com-mudanca)
-
-    (let [url (str "https://api.gupshup.io/sm/api/v1/template/list/" app-id) ; URL Original restaurada
-          ]
-      (println (str "[WORKER] Tentando conexão com a API Gupshup. App ID: " app-id ", URL: " url))
+      (println (str "[WORKER] Usando MOCK_CUSTOMER_MANAGER_WABA_IDS: " customer-manager-mock-waba-ids-str))
+      (map str/trim (str/split customer-manager-mock-waba-ids-str #",")))
+    (if customer-manager-url
       (try
-        (let [response (client/get url {:headers          {:apikey token} ; Header restaurado
+        (let [full-url (str customer-manager-url "/internal/customers/active-waba-ids")]
+          (println (str "[WORKER] Buscando WABA IDs de: " full-url))
+          (let [response (client/get full-url {:as :json :throw-exceptions false :conn-timeout 5000 :socket-timeout 5000})]
+            (if (= (:status response) 200)
+              (let [ids (:body response)]
+                (if (and (vector? ids) (every? string? ids))
+                  (do
+                    (println (str "[WORKER] WABA IDs recebidos: " ids))
+                    ids)
+                  (do
+                    (println (str "[WORKER] Resposta inesperada do customer-manager-service (formato inválido): " (:body response) ". Esperado um vetor de strings."))
+                    [])))
+              (do
+                (println (str "[WORKER] Erro ao buscar WABA IDs do customer-manager-service. Status: " (:status response) ". Corpo: " (:body response)))
+                []))))
+        (catch Exception e
+          (println (str "[WORKER] Exceção ao buscar WABA IDs do customer-manager-service: " (.getMessage e)))
+          (.printStackTrace e)
+          []))
+      (do
+        (println "[WORKER] ERRO: Nem MOCK_CUSTOMER_MANAGER_WABA_IDS nem CUSTOMER_MANAGER_URL estão definidos. Não é possível buscar WABA IDs.")
+        []))))
+
+(defn fetch-templates-for-waba
+  "Busca templates para um WABA ID específico. Usa dados de teste ou chama a API real."
+  [waba-id token]
+  (if gupshup-mock-mode?
+    (do
+      (println (str "[GUPSHUP_MOCK_MODE] Usando dados mockados para WABA ID: " waba-id))
+      (let [mocked-data (get @mock-templates-store waba-id [])]
+        (println (str "[GUPSHUP_MOCK_MODE] Dados para " waba-id ": " (count mocked-data) " templates."))
+        mocked-data))
+
+    (let [url (str "https://api.gupshup.io/sm/api/v1/template/list/" waba-id)]
+      (println (str "[WORKER] Tentando conexão com a API Gupshup. WABA ID: " waba-id ", URL: " url))
+      (try
+        (let [response (client/get url {:headers          {:apikey token}
                                         :as               :json
                                         :throw-exceptions false
                                         :conn-timeout     60000
-                                        :socket-timeout   60000
-                                        })]
-          (println (str "[WORKER] Resposta recebida da API Gupshup. Status HTTP: " (:status response)))
+                                        :socket-timeout   60000})]
+          (println (str "[WORKER] Resposta recebida da API Gupshup para WABA ID " waba-id ". Status HTTP: " (:status response)))
 
           (cond
-            ;; Erro na própria requisição HTTP (ex: timeout, problema de rede antes de receber status)
-            ;; :error é preenchido por clj-http em alguns casos de falha de request
             (:error response)
             (do
-              (println (str "[WORKER] Erro crítico de HTTP ao buscar templates: " (:error response)))
+              (println (str "[WORKER] Erro crítico de HTTP ao buscar templates para WABA ID " waba-id ": " (:error response)))
               (when-let [cause (:cause (:error response))]
                 (println (str "Causa: " cause)))
-              nil)
+              nil) ; Retorna nil em caso de erro crítico de HTTP
 
-            ;; Resposta HTTP não foi 200 OK
             (not= (:status response) 200)
             (do
-              (println (str "[WORKER] Erro ao buscar templates da Gupshup. Status HTTP: " (:status response) ". Corpo da resposta (se houver):"))
+              (println (str "[WORKER] Erro ao buscar templates da Gupshup para WABA ID " waba-id ". Status HTTP: " (:status response) ". Corpo:"))
               (pprint/pprint (:body response))
-              nil)
+              nil) ; Retorna nil se o status não for 200
 
-            ;; Resposta HTTP foi 200 OK, mas o corpo não é um mapa (ex: string não-JSON que clj-http não conseguiu parsear com :as :json)
             (not (map? (:body response)))
             (do
-              (println "[WORKER] Resposta da API Gupshup (status 200 OK) mas corpo não é um mapa JSON. Corpo:")
+              (println (str "[WORKER] Resposta da API Gupshup (status 200 OK) para WABA ID " waba-id " mas corpo não é um mapa JSON. Corpo:"))
               (pprint/pprint (:body response))
-              (println "\n!!!! [WORKER] ALERTA: Corpo da API Gupshup não é um mapa JSON válido após status 200 OK. Retornando nil. !!!!")
-              (println (str "Tipo do corpo recebido: " (type (:body response))))
-              (println "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-              nil)
+              (println (str "\n!!!! [WORKER] ALERTA: Corpo da API Gupshup para WABA ID " waba-id " não é um mapa JSON válido. Retornando nil. !!!!"))
+              nil) ; Retorna nil se o corpo não for um mapa
 
-            ;; Tudo OK, corpo é um mapa, prossiga para extrair templates
             :else
-            (do
-              (println "[WORKER] Resposta da API Gupshup (status 200 OK). Corpo:")
-              (pprint/pprint (:body response))
-              (or (get-in (:body response) [:templates]) [])))) ; Garante [] se :templates for nil ou ausente
+            (let [templates (get-in (:body response) [:templates])]
+              (println (str "[WORKER] Templates recebidos da API Gupshup para WABA ID " waba-id ": " (count templates) " templates."))
+              (or templates [])))) ; Garante [] se :templates for nil ou ausente na resposta bem-sucedida
 
-        (catch Exception e ; Captura exceções de rede (como ConnectException) ou outras exceções inesperadas.
-          (println "\n!!!! [WORKER] Exceção CRÍTICA ao conectar com a API Gupshup ou processar resposta !!!!")
+        (catch Exception e
+          (println (str "\n!!!! [WORKER] Exceção CRÍTICA ao conectar com a API Gupshup para WABA ID " waba-id " ou processar resposta !!!!"))
           (println (str "Tipo da exceção: " (type e)))
           (println (str "Mensagem: " (.getMessage e)))
           (.printStackTrace e)
-          (println "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-          nil)))))
+          nil))))) ; Retorna nil em caso de exceção durante a chamada HTTP
 
 (defn log-category-change
-  [template]
-  (let [id          (get template :id)
-        elementName (get template :elementName)
-        oldCategory (get template :oldCategory)
-        newCategory (get template :category)]
-    (println (str "[WORKER] Mudança de categoria detectada para o template:"))
-    (println (str "  ID: " id))
+  "Loga a mudança de categoria de um template."
+  [template waba-id]
+  (let [template-id (get template "id") ; Gupshup API usa strings para chaves
+        elementName (get template "elementName")
+        oldCategory (get template "oldCategory")
+        newCategory (get template "category")]
+    (println (str "[WORKER] Mudança de categoria detectada:"))
+    (println (str "  WABA ID: " waba-id))
+    (println (str "  ID do Template: " template-id))
     (println (str "  Nome: " elementName))
     (println (str "  Categoria Antiga: " oldCategory))
     (println (str "  Nova Categoria: " newCategory))))
 
-(defn check-for-changes
-  [app-id token]
-  (println "[WORKER] Executando verificação de templates...")
-  (if-let [all-templates (fetch-templates app-id token)]
-    (let [total-received (count all-templates)
-          ;; Primeiro, filtra para garantir que estamos lidando apenas com mapas
-          map-templates (filter map? all-templates)
-          ;; Filtra para incluir apenas templates que NÃO estão com status "FAILED" a partir dos map-templates
-          active-templates (filter #(not= (:status %) "FAILED") map-templates)
-          total-active (count active-templates)
+(defn process-templates-for-waba
+  "Processa templates para um WABA ID, identifica mudanças e retorna os alterados,
+   associando o waba-id a cada template alterado."
+  [waba-id token]
+  (println (str "[WORKER] Iniciando processamento de templates para WABA ID: " waba-id))
+  (if-let [all-templates (fetch-templates-for-waba waba-id token)] ; all-templates pode ser nil se fetch falhar
+    (if (seq all-templates) ; Procede somente se houver templates
+      (let [total-received (count all-templates)
+            map-templates (filter map? all-templates) ; Garante que são mapas
+            ;; Filtra para incluir apenas templates que NÃO estão com status "FAILED"
+            active-templates (filter #(not= (get % "status") "FAILED") map-templates)
+            total-active (count active-templates)
+            ;; Filtra templates ativos que possuem a chave "oldCategory" (indicando mudança)
+            changed-category-templates (filter #(contains? % "oldCategory") active-templates)
+            count-changed (count changed-category-templates)]
 
-          ;; Filtra templates ativos que possuem a chave :oldCategory
-          templates-with-old-category (filter #(contains? % :oldCategory) active-templates)
-          count-changed (count templates-with-old-category)]
+        (println (str "[WORKER] Detalhes para WABA ID " waba-id ":"))
+        (println (str "  Total de templates recebidos: " total-received "."))
+        (when (not= total-received (count map-templates))
+          (println (str "  AVISO: " (- total-received (count map-templates)) " itens não-mapa foram ignorados.")))
+        (println (str "  Total de templates ativos (não FAILED e são mapas): " total-active "."))
 
-      (println (str "[WORKER] Total de templates recebidos da API: " total-received "."))
-      (when (not= total-received (count map-templates))
-        (println (str "[WORKER] Número de itens não-mapa ignorados: " (- total-received (count map-templates)) ".")))
-      (println (str "[WORKER] Total de templates ativos (não FAILED, apenas mapas) sendo processados: " total-active "."))
+        (if (pos? count-changed)
+          (do
+            (println (str "  Dentre os ativos, " count-changed " templates com mudança de categoria encontrados."))
+            (doseq [template changed-category-templates]
+              (log-category-change template waba-id))
+            ;; Adiciona/atualiza o wabaId em cada template alterado para garantir consistência
+            (map #(assoc % "wabaId" waba-id) changed-category-templates))
+          (do
+            (println (str "  Nenhum template ativo com mudança de categoria encontrado para o WABA ID " waba-id "."))
+            []))) ; Retorna lista vazia se não houver mudanças
+      (do
+        (println (str "[WORKER] Nenhum template recebido ou lista vazia para WABA ID " waba-id "."))
+        [])) ; Retorna lista vazia se não houve templates
+    (do
+      (println (str "[WORKER] Falha ao obter templates para WABA ID " waba-id ". Não foi possível processar."))
+      []))) ; Retorna lista vazia em caso de falha total no fetch
 
-      (if (pos? count-changed)
+(defn check-all-waba-ids-for-changes!
+  "Busca todos os WABA IDs e verifica mudanças de templates para cada um,
+   atualizando o atom `changed-templates-atom`."
+  []
+  (println "[WORKER] Iniciando ciclo de verificação de todos os WABA IDs...")
+  (if (str/blank? gupshup-token)
+    (println "[WORKER] ERRO CRÍTICO: GUPSHUP_TOKEN não está definido. Não é possível buscar templates.")
+    (let [waba-ids (fetch-waba-ids)]
+      (if (empty? waba-ids)
         (do
-          (println (str "[WORKER] Dentre os ativos, " count-changed " templates com mudança de categoria encontrados."))
-          (doseq [template templates-with-old-category]
-            (log-category-change template)))
-        (println "[WORKER] Nenhum template ativo com mudança de categoria encontrado.")))
-    (println "[WORKER] Não foi possível obter a lista de templates para verificação.")))
+          (println "[WORKER] Nenhum WABA ID para processar. Limpando lista de templates alterados.")
+          (reset! changed-templates-atom []))
+        (let [all-changed-templates (->> waba-ids
+                                         (mapcat #(process-templates-for-waba % gupshup-token))
+                                         (filter identity) ; Remove nils que podem ter vindo de process-templates-for-waba
+                                         vec)] ; Converte para vetor
+          (println (str "[WORKER] Total de templates com mudança de categoria em todos os WABA IDs: " (count all-changed-templates)))
+          (reset! changed-templates-atom all-changed-templates)
+          (if (seq @changed-templates-atom)
+            (println (str "[WORKER] Lista de templates alterados atualizada. " (count @changed-templates-atom) " templates armazenados."))
+            (println "[WORKER] Lista de templates alterados está vazia após a verificação.")))))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;  3. LÓGICA DO SERVIDOR E PONTO DE ENTRADA
+;;  3. LÓGICA DO SERVIDOR HTTP E PONTO DE ENTRADA
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- start-watcher-loop!
+  "Inicia o loop em background que periodicamente verifica por mudanças."
   []
-  (let [app-id (System/getenv "GUPSHUP_APP_ID")
-        token  (System/getenv "GUPSHUP_TOKEN")]
-    (if (and app-id token)
-      (future
-        (println "[WORKER] Watcher em background iniciado. Aguardando 30s antes do primeiro ciclo...")
-        (Thread/sleep 30000) ; Atraso inicial de 30 segundos
-        (loop []
-          (try
-            (check-for-changes app-id token)
-            (println "[WORKER] Verificação concluída. Próximo ciclo em 10 minutos.")
-            (catch Throwable t ; Captura qualquer Throwable
-              (println "\n!!!! [WORKER] Exceção INESPERADA no loop principal do watcher !!!!")
-              (println (str "Tipo da exceção: " (type t)))
-              (println (str "Mensagem: " (.getMessage t)))
-              (.printStackTrace t)
-              (println "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-              (println "[WORKER] Erro no ciclo. Tentando novamente em 10 minutos.")))
-          (Thread/sleep 600000) ; Intervalo de 10 minutos
-          (recur)))
-      (println "ERRO CRÍTICO: Variáveis de ambiente não definidas."))))
+  (initialize-mock-gupshup-store!) ; Garante que o mock store seja inicializado se o modo mock estiver ativo.
+  (if (str/blank? gupshup-token)
+    (println "[WORKER_SETUP] ERRO CRÍTICO: GUPSHUP_TOKEN não está definido. O watcher não pode iniciar.")
+    (future
+      (println "[WORKER] Watcher em background iniciado. Primeiro ciclo em 30 segundos...")
+      (Thread/sleep 30000) ; Atraso inicial
+      (loop []
+        (try
+          (check-all-waba-ids-for-changes!) ; Chama a função que atualiza o atom
+          (println "[WORKER] Verificação de todos os WABA IDs concluída. Próximo ciclo em 10 minutos.")
+          (catch Throwable t ; Captura qualquer Throwable para evitar que o loop morra
+            (println "\n!!!! [WORKER] Exceção INESPERADA no loop principal do watcher !!!!")
+            (println (str "  Tipo da exceção: " (type t)))
+            (println (str "  Mensagem: " (.getMessage t)))
+            (.printStackTrace t)
+            (println "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+            (println "[WORKER] Erro no ciclo. Tentando novamente em 10 minutos.")))
+        (Thread/sleep 600000) ; Intervalo de 10 minutos (600,000 ms)
+        (recur)))))
 
 (defn app-handler
+  "Manipulador de requisições HTTP."
   [request]
-  {:status  200
-   :headers {"Content-Type" "text/plain"}
-   :body    "Serviço Notification Watcher está no ar."})
+  (case (:uri request)
+    "/"
+    {:status  200
+     :headers {"Content-Type" "text/plain; charset=utf-8"}
+     :body    "Serviço Notification Watcher está no ar."}
+
+    "/changed-templates"
+    {:status  200
+     :headers {"Content-Type" "application/json; charset=utf-8"}
+     :body    (json/write-str @changed-templates-atom)} ; Serve o conteúdo do atom
+
+    ;; else (404 Not Found)
+    {:status  404
+     :headers {"Content-Type" "text/plain; charset=utf-8"}
+     :body    "Recurso não encontrado."}))
 
 (defn -main
+  "Ponto de entrada principal da aplicação."
   [& args]
   (let [port (Integer/parseInt (or (System/getenv "PORT") "8080"))]
-    (println (str "[SERVER] Iniciando servidor web na porta " port "."))
-    (start-watcher-loop!)
+    (println (str "[SERVER] Notification Watcher iniciando..."))
+    (println (str "[SERVER] Configurações:"))
+    (println (str "  GUPSHUP_MOCK_MODE: " gupshup-mock-mode?))
+    (println (str "  MOCK_CUSTOMER_MANAGER_WABA_IDS: " (if customer-manager-mock-waba-ids-str customer-manager-mock-waba-ids-str "Não definido")))
+    (println (str "  CUSTOMER_MANAGER_URL: " (if customer-manager-url customer-manager-url "Não definido")))
+    (println (str "  GUPSHUP_TOKEN: " (if (str/blank? gupshup-token) "NÃO DEFINIDO (CRÍTICO!)" "Definido (oculto)")))
+    (println (str "  PORT: " port))
+
+    (start-watcher-loop!) ; Inicia o processo em background
+
     (server/run-server #'app-handler {:port port})
-    (println "[SERVER] Servidor iniciado. O watcher está rodando em background.")))
+    (println (str "[SERVER] Servidor HTTP iniciado na porta " port "."))
+    (println "[SERVER] Notification Watcher está rodando.")))


### PR DESCRIPTION
- Implements /changed-templates endpoint to show templates with category changes.
- Adds support for multiple WABA IDs, fetched from customer-manager-service or mock environment variable.
- Introduces GUPSHUP_MOCK_MODE for Gupshup API mocking.
- Updates README with new configurations and endpoint details.